### PR TITLE
Fixed bug of spawning above or below ground

### DIFF
--- a/mellotrainer/cl_general.lua
+++ b/mellotrainer/cl_general.lua
@@ -41,47 +41,44 @@ end)
 
 -- Teleport to map blip
 function teleportToWaypoint()
-	local targetPed = GetPlayerPed(-1)
-	if(IsPedInAnyVehicle(targetPed))then
-		targetPed = GetVehiclePedIsUsing(targetPed)
-	end
-
-	if(not IsWaypointActive())then
-		drawNotification("Map Marker not found.")
-		return
-	end
-
-	local waypointBlip = GetFirstBlipInfoId(8) -- 8 = Waypoint ID
-	local x,y,z = table.unpack(Citizen.InvokeNative(0xFA7C7F0AADF25D09, waypointBlip, Citizen.ResultAsVector())) 
-
-
-
-	-- Ensure Entity teleports above the ground
-	local ground
-	local groundFound = false
-	local groundCheckHeights = {0.0, 50.0, 100.0, 150.0, 200.0, 250.0, 300.0, 350.0, 400.0,450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0, 800.0}
-
-
-	for i,height in ipairs(groundCheckHeights) do
-		RequestCollisionAtCoord(x, y, height)
-		Wait(0)
-		SetEntityCoordsNoOffset(targetPed, x,y,height, 0, 0, 1)
-		ground,z = GetGroundZFor_3dCoord(x,y,height)
-		if(ground) then
-			z = z + 3
-			groundFound = true
-			break;
+	Citizen.CreateThread(function()
+		local targetPed = GetPlayerPed(-1)
+		if(IsPedInAnyVehicle(targetPed))then
+			targetPed = GetVehiclePedIsUsing(targetPed)
 		end
-	end
+	
+		if(not IsWaypointActive())then
+			drawNotification("~r~Map Marker not found.")
+			return
+		end
+	
+		local waypointBlip = GetFirstBlipInfoId(8) -- 8 = Waypoint ID
+		local x,y,z = table.unpack(Citizen.InvokeNative(0xFA7C7F0AADF25D09, waypointBlip, Citizen.ResultAsVector())) 
 
-	if(not groundFound)then
-		z = 1000
-		GiveDelayedWeaponToPed(PlayerPedId(), 0xFBAB5776, 1, 0) -- Parachute
-	end
-
-	SetEntityCoordsNoOffset(targetPed, x,y,z, 0, 0, 1)
-
-	drawNotification("Teleported to waypoint.")
+		
+		-- Ensure Entity teleports above the ground
+		local ground
+		local groundFound = false
+		
+		for height=1.0,800.0,7.0 do
+			RequestCollisionAtCoord(x, y, height)
+			Wait(0)
+			SetEntityCoordsNoOffset(targetPed, x,y,height, 0, 0, 1)
+			ground,z = GetGroundZFor_3dCoord(x,y,height)
+			if(ground) then
+				groundFound = true
+				break;
+			end
+		end
+	
+		if(not groundFound)then
+			z = 1000
+			GiveDelayedWeaponToPed(PlayerPedId(), 0xFBAB5776, 1, 0) -- Parachute
+			SetEntityCoordsNoOffset(targetPed, x,y,z, 0, 0, 1)
+		end
+	
+		drawNotification("~g~Teleported to waypoint.")
+	end)
 end
 
 


### PR DESCRIPTION
I fixed the bug by simply going by 7 float intervals to the ground was found, instead of going by 50 float intervals in a list.

Check commit [here](https://github.com/blockba5her/mellotrainer/commit/0e3d77128fb67773b016e9f0e82cb5e9face746e)